### PR TITLE
Allow to change the datalog directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A puppet module for [Apache Kafka](http://kafka.apache.org/) setup.
    - `hostname` - the hostname to bind. expected to be available for other brokers and clients
    - `zookeeper_connect` - zookeeper connection string
    - `package_url` - might use http, ftp, puppet or file scheme
+   - `datalog_dir` - the path where kafka should store data. By default /tmp/kafka-logs
    - `statsd_host` - the statsd hostname
    - `statsd_port` - the statsd port
    - `statsd_exclude_regex` - the statsd exclude.regex eg. (?!(AllTopicsBytesInPerSec|AllTopicsBytesOutPerSec|AllTopicsMessagesInPerSec|AllTopicsFailedProduceRequestsPerSec)).+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,7 @@ class kafka (
   $package_dir = $kafka::params::package_dir,
   $package_url = $kafka::params::package_url,
   $install_dir = $kafka::params::install_dir,
+  $datalog_dir = $kafka::params::datalog_dir,
   $log_retention_hours = $kafka::params::log_retention_hours,
   $statsd_host = $kafka::params::statsd_host,
   $statsd_port = $kafka::params::statsd_port,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,7 @@ class kafka::params {
   $package_url          = hiera('kafka:package_url', undef)
   $install_dir          = hiera('kafka:install_dir', '/usr/local/kafka')
   $hostname             = hiera('kafka:hostname', $::ipaddress)
+  $datalog_dir          = hiera('kafka:datalog_dir', '/tmp/kafka-logs')
   $log_retention_hours  = hiera('kafka:log_retention_hours', '168')
   $statsd_host          = hiera('kafka:statsd_host', $::statsd_host)
   $statsd_port          = hiera('kafka:statsd_port', $::statsd_port)

--- a/templates/config/server.properties.erb
+++ b/templates/config/server.properties.erb
@@ -51,7 +51,9 @@ socket.request.max.bytes=104857600
 ############################# Log Basics #############################
 
 # A comma seperated list of directories under which to store log files
-log.dirs=/tmp/kafka-logs
+<% unless @datalog_dir.nil? || @datalog_dir.empty? -%>
+log.dirs=<%= @datalog_dir %>
+<% end -%>
 
 # The number of logical partitions per topic per server. More partitions allow greater parallelism
 # for consumption, but also mean more files.


### PR DESCRIPTION
This change allows us to use a non volatile folder for kafka like /tmp