### PR TITLE
Log retention minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ A puppet module for [Apache Kafka](http://kafka.apache.org/) setup.
    - `package_url` - might use http, ftp, puppet or file scheme
    - `logs_dir` - the path where kafka should store its logs. By default /var/log/kafka/
    - `datalog_dir` - the path where kafka should store data. By default /tmp/kafka-logs
+   - `log_retention_minutes` - How many minutes the datalog should be keept since last write to it. If defined, takes preference over log_retention_hours. By default is not defined.
+   - `log_retention_hours` - How many hours the datalog should be keept since last write to it. By default 168 hours.
    - `statsd_host` - the statsd hostname
    - `statsd_port` - the statsd port
    - `statsd_exclude_regex` - the statsd exclude.regex eg. (?!(AllTopicsBytesInPerSec|AllTopicsBytesOutPerSec|AllTopicsMessagesInPerSec|AllTopicsFailedProduceRequestsPerSec)).+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,7 @@ class kafka (
   $logs_dir = $kafka::params::logs_dir,
   $datalog_dir = $kafka::params::datalog_dir,
   $log_retention_hours = $kafka::params::log_retention_hours,
+  $log_retention_minutes = $kafka::params::log_retention_minutes,
   $statsd_host = $kafka::params::statsd_host,
   $statsd_port = $kafka::params::statsd_port,
   $statsd_enabled = $kafka::params::statsd_enabled,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,6 +7,7 @@ class kafka::params {
   $hostname             = hiera('kafka:hostname', $::ipaddress)
   $datalog_dir          = hiera('kafka:datalog_dir', '/tmp/kafka-logs')
   $log_retention_hours  = hiera('kafka:log_retention_hours', '168')
+  $log_retention_minutes = hiera('kafka:log_retention_minutes', undef)
   $statsd_host          = hiera('kafka:statsd_host', $::statsd_host)
   $statsd_port          = hiera('kafka:statsd_port', $::statsd_port)
   $statsd_enabled       = hiera('kafka:statsd_enabled', $::statsd_enabled)

--- a/templates/config/server.properties.erb
+++ b/templates/config/server.properties.erb
@@ -88,9 +88,11 @@ log.flush.interval.ms=1000
 
 # The minimum age of a log file to be eligible for deletion
 #
-<% unless @log_retention_hours.nil? || @log_retention_hours.empty? %>
+<% if @log_retention_minutes -%>
+log.retention.minutes=<%= @log_retention_minutes %>
+<% elsif @log_retention_hours -%>
 log.retention.hours=<%= @log_retention_hours %>
-<% end %>
+<% end -%>
 
 # A size-based retention policy for logs. Segments are pruned from the log as long as the remaining
 # segments don't drop below log.retention.bytes.

--- a/templates/config/server.properties.erb
+++ b/templates/config/server.properties.erb
@@ -88,9 +88,9 @@ log.flush.interval.ms=1000
 
 # The minimum age of a log file to be eligible for deletion
 #
-<% if @log_retention_minutes -%>
+<% if !@log_retention_minutes.nil? && !@log_retention_minutes.empty? -%>
 log.retention.minutes=<%= @log_retention_minutes %>
-<% elsif @log_retention_hours -%>
+<% elsif !@log_retention_hours.nil? && !@log_retention_hours.empty? -%>
 log.retention.hours=<%= @log_retention_hours %>
 <% end -%>
 


### PR DESCRIPTION
This patch adds support for the log.retention.minutes setting so we are able to set a value lower than one hour. It was added with Kafka 0.8.1 (https://issues.apache.org/jira/browse/KAFKA-918)

If no retention setting is provider (minutes or hours) we use by default the 168 hours one we used to have here. If both are provided, the minutes one "wins".
